### PR TITLE
Add patch-package and update rn-nodeify

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,4 @@ The biggest problem is that React Native does not support the Web Crypto API. Ho
 1. Clone this repository
 2. Install dependencies by running `yarn`
 3. Enter your app credentials in the `App.tsx` file.
-4. Change the constant `HASH_ALGORITHM_NAME` in `node_modules/userbase-js/lib/Crypto/sha-256.js` to `sha-256`. This has to be done because of an issue with `browserify-sign` which is used by `rn-nodeify` (See [here](https://github.com/crypto-browserify/browserify-sign/issues/71))
-5. Run the app
-
-Disclaimer: For now, you have to change the following in the file located in `/node_modules/parse-asn1/node_modules/pbkdf2/lib/default-encoding.js`:
-`global."v15.12.0"` to `global.process.version`
-This is due to an issue in `rn-nodeify` (See [here](https://github.com/tradle/rn-nodeify/issues/104))
+4. Run the app

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "postinstall": "rn-nodeify --hack --install"
+    "postinstall": "rn-nodeify --hack --install; patch-package"
   },
   "dependencies": {
     "@peculiar/webcrypto": "^1.1.6",
@@ -56,8 +56,9 @@
     "eslint": "^7.14.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.64.0",
+    "patch-package": "^6.4.7",
     "react-test-renderer": "17.0.1",
-    "rn-nodeify": "^10.2.0",
+    "rn-nodeify": "^10.3.0",
     "typescript": "^3.8.3"
   },
   "resolutions": {

--- a/patches/userbase-js+2.8.0.patch
+++ b/patches/userbase-js+2.8.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/userbase-js/lib/Crypto/sha-256.js b/node_modules/userbase-js/lib/Crypto/sha-256.js
+index 007a390..60a8168 100644
+--- a/node_modules/userbase-js/lib/Crypto/sha-256.js
++++ b/node_modules/userbase-js/lib/Crypto/sha-256.js
+@@ -2,7 +2,7 @@ import base64 from 'base64-arraybuffer';
+ import { stringToArrayBuffer } from './utils';
+ const BYTE_SIZE = 32; // 256 / 8
+ 
+-const HASH_ALGORITHM_NAME = 'SHA-256';
++const HASH_ALGORITHM_NAME = 'sha-256';
+ /**
+  *
+  * @param {ArrayBuffer} data

--- a/patches/userbase-js+2.8.0.patch
+++ b/patches/userbase-js+2.8.0.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/userbase-js/dist/userbase.cjs.js b/node_modules/userbase-js/dist/userbase.cjs.js
+index 7b2b33f..66ce6fd 100644
+--- a/node_modules/userbase-js/dist/userbase.cjs.js
++++ b/node_modules/userbase-js/dist/userbase.cjs.js
+@@ -2263,7 +2263,7 @@ const hexStringToArrayBuffer = hexString => {
+ 
+ const BYTE_SIZE = 32; // 256 / 8
+ 
+-const HASH_ALGORITHM_NAME = 'SHA-256';
++const HASH_ALGORITHM_NAME = 'sha-256';
+ /**
+  *
+  * @param {ArrayBuffer} data
 diff --git a/node_modules/userbase-js/lib/Crypto/sha-256.js b/node_modules/userbase-js/lib/Crypto/sha-256.js
 index 007a390..60a8168 100644
 --- a/node_modules/userbase-js/lib/Crypto/sha-256.js


### PR DESCRIPTION
Adding `patch-package` to manage local dependency code changes. This is used to modify Userbase's hash algorithm name, changing it to lowercase `sha-256` to work with browserify-sign which is used by rn-nodeify. The change will be made automatically when installing dependencies, triggered by the `postinstall` script in `package.json`.

Also updating `rn-nodeify` to 10.3.0 which includes a PR from @Fubinator.