### PR TITLE
add: getRandomValues polyfill

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,10 @@ const App = () => {
 
           console.log('USER: ', user);
         }
+
+        const dbs = await userbase.getDatabases();
+
+        console.log('DB OPEN', dbs);
       } catch (error) {
         console.log(error);
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "17.0.1",
     "react-native": "0.64.0",
     "react-native-crypto": "^2.2.0",
+    "react-native-get-random-values": "^1.7.0",
     "react-native-level-fs": "^3.0.1",
     "react-native-os": "^1.2.6",
     "react-native-randombytes": "^3.6.0",

--- a/patches/react-native-get-random-values+1.7.0.patch
+++ b/patches/react-native-get-random-values+1.7.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/react-native-get-random-values/index.js b/node_modules/react-native-get-random-values/index.js
+index df701c3..5b410aa 100644
+--- a/node_modules/react-native-get-random-values/index.js
++++ b/node_modules/react-native-get-random-values/index.js
+@@ -63,6 +63,6 @@ if (typeof global.crypto !== 'object') {
+   global.crypto = {}
+ }
+ 
+-if (typeof global.crypto.getRandomValues !== 'function') {
+-  global.crypto.getRandomValues = getRandomValues
+-}
++// if (typeof global.crypto.getRandomValues !== 'function') {
++  export default global.crypto.getRandomValues = getRandomValues
++  // }

--- a/userbase.ts
+++ b/userbase.ts
@@ -1,22 +1,20 @@
+// @ts-nocheck
 import './shim.js';
-
+import getRandomValues from 'react-native-get-random-values';
 const {Crypto} = require('@peculiar/webcrypto');
-//@ts-ignore
 import localStorage from 'react-native-sync-localstorage';
 
 export default async function initialize(): Promise<void> {
   // crypto
-  //@ts-ignore
   global.crypto = new Crypto();
+  global.crypto.getRandomValues = getRandomValues;
 
   // localStorage
   await localStorage.getAllFromLocalStorage();
-  //@ts-ignore
   global.localStorage = localStorage;
 
   // sessionStorage
   // https://gist.github.com/juliocesar/926500#gistcomment-1620487
-  // @ts-ignore
   global.sessionStorage = {
     _data: {},
     setItem: function (id: string, val: any) {
@@ -36,6 +34,5 @@ export default async function initialize(): Promise<void> {
   };
 
   // DOMException
-  // @ts-ignore
   global.DOMException = require('domexception');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3154,6 +3154,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -6036,6 +6041,13 @@ react-native-crypto@^2.2.0:
     pbkdf2 "3.0.8"
     public-encrypt "^4.0.0"
     randomfill "^1.0.3"
+
+react-native-get-random-values@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.7.0.tgz#86d9d1960828b606392dba4540bf760605448530"
+  integrity sha512-zDhmpWUekGRFb9I+MQkxllHcqXN9HBSsgPwBQfrZ1KZYpzDspWLZ6/yLMMZrtq4pVqNR7C7N96L3SuLpXv1nhQ==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 react-native-level-fs@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
fixes #13 

`global.crypto.getRandomValues` gets polyfilled by `react-native-get-random-values`.

`openDatabase` and `getDatabases` are working with this patch.